### PR TITLE
highlight calls to erlang modules as types

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -64,6 +64,10 @@
 
 (alias) @type
 
+(call
+  target: (dot
+            left: (atom) @type))
+
 (char) @constant
 
 ; Quoted content


### PR DESCRIPTION
:wave: hello!

I'm integrating the new parser and highlight queries into the [helix](https://github.com/helix-editor/helix) editor (see [helix-editor/helix#830](https://github.com/helix-editor/helix/pull/830)) and I noticed that a function call on an atom highlights differently than an alias (module). This PR adds a clause to the highlights to recognize that case and highlight the atom the same as an alias:

![highlight-atom-modules-as-types](https://user-images.githubusercontent.com/21230295/137020231-43f4050c-6dc9-47c7-b5aa-cd61cf32e891.png)

<sup>before | after</sup>

What do you think?