### PR TITLE
Make C++ source compatible with older standards

### DIFF
--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -104,11 +104,13 @@ const char token_terminators[] = {
   '#'
 };
 
+const uint8_t token_terminators_length = sizeof(token_terminators) / sizeof(char);
+
 // Note: this is a heuristic as we only use this to distinguish word
 // operators and we don't want to include complex Unicode ranges
 bool is_token_end(int32_t c) {
-  for (const char& terminator : token_terminators) {
-    if (c == terminator) {
+  for (uint8_t i = 0; i < token_terminators_length; i++) {
+    if (c == token_terminators[i]) {
       return true;
     }
   }
@@ -598,7 +600,7 @@ bool scan(TSLexer* lexer, const bool* valid_symbols) {
 
 extern "C" {
   void* tree_sitter_elixir_external_scanner_create() {
-    return nullptr;
+    return NULL;
   }
 
   bool tree_sitter_elixir_external_scanner_scan(void* payload, TSLexer* lexer, const bool* valid_symbols) {


### PR DESCRIPTION
Closes #6.

Tested by explicitly compiling with `-std=c++98`.

```
➜  tree-sitter-elixir git:(main) gcc -o tmp/parser.so -I./src src/parser.c src/scanner.cc -shared -fPIC -std=c++98
cc1: warning: command-line option ‘-std=c++98’ is valid for C++/ObjC++ but not for C
src/scanner.cc: In function ‘bool {anonymous}::is_token_end(int32_t)’:
src/scanner.cc:110:33: warning: range-based ‘for’ loops only available with ‘-std=c++11’ or ‘-std=gnu++11’
  110 |   for (const char& terminator : token_terminators) {
      |                                 ^~~~~~~~~~~~~~~~~
src/scanner.cc:110:33: error: forming reference to reference type ‘const char (&)[27]’
src/scanner.cc: In function ‘void* {anonymous}::tree_sitter_elixir_external_scanner_create()’:
src/scanner.cc:601:12: error: ‘nullptr’ was not declared in this scope
  601 |     return nullptr;
      |            ^~~~~~~
```

After the change, it compiles fine.