### PR TITLE
Highlight 'not in' as keyword

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,6 +1,6 @@
 ; Reserved keywords
 
-["when" "and" "or" "not" "in" "fn" "do" "end" "catch" "rescue" "after" "else"] @keyword
+["when" "and" "or" "not" "in" "not in" "fn" "do" "end" "catch" "rescue" "after" "else"] @keyword
 
 ; Operators
 

--- a/test/highlight/operators.ex
+++ b/test/highlight/operators.ex
@@ -1,3 +1,20 @@
+a in b
+# <- variable
+# ^ keyword
+#    ^ variable
+
+a not in b
+# <- variable
+# ^ keyword
+#     ^ keyword
+#        ^ variable
+
+a not  in b
+# <- variable
+# ^ keyword
+#      ^ keyword
+#         ^ variable
+
 a ~>> b = bind(a, b)
 # <- variable
 #  ^ operator


### PR DESCRIPTION
`not in` is a single token, so `"not"` and `"in"` queries don't match it. Fortunately with the alias introduced in #10 we can query `"not in"` and it matches regardless of the whitespace between `not` and `in`.

@connorlay we probably need to adjust the query in nvim-tree-sitter accordingly, unless it's already matched in some other way :)