### PR TITLE
Rename module highlight token

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -62,11 +62,11 @@
   (float)
 ] @number
 
-(alias) @type
+(alias) @module
 
 (call
   target: (dot
-    left: (atom) @type))
+    left: (atom) @module))
 
 (char) @constant
 

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -56,7 +56,10 @@ bool is_inline_whitespace(int32_t c) {
 }
 
 bool is_newline(int32_t c) {
-  return c == '\n';
+  // Note: this implies \r\n is treated as two line breaks,
+  // but in our case it's fine, since multiple line breaks
+  // make no difference
+  return c == '\n' || c == '\r';
 }
 
 bool is_digit(int32_t c) {

--- a/test/highlight/anonymous.ex
+++ b/test/highlight/anonymous.ex
@@ -43,7 +43,7 @@ end
 
 &Set.put(&1, &2)
 # <- operator
-# ^ type
+# ^ module
 #   ^ operator
 #    ^ function
 #       ^ punctuation.bracket
@@ -55,7 +55,7 @@ end
 &( Set.put(&1, &1) )
 #<- operator
 #^ punctuation.bracket
-#  ^ type
+#  ^ module
 #     ^ operator
 #      ^ function
 #         ^ punctuation.bracket

--- a/test/highlight/calls.ex
+++ b/test/highlight/calls.ex
@@ -1,5 +1,5 @@
 Path.expand("..", __DIR__)
-# ^ type
+# ^ module
 #   ^ operator
 #    ^ function
 #          ^ punctuation.bracket
@@ -35,7 +35,7 @@ hd([1,2])
 #       ^ punctuation.bracket
 
 Kernel.spawn(fn -> :ok end)
-# ^ type
+# ^ module
 #     ^ operator
 #      ^ function
 #           ^ punctuation.bracket
@@ -46,12 +46,12 @@ Kernel.spawn(fn -> :ok end)
 #                         ^ punctuation.bracket
 
 IO.ANSI.black
-# ^ type
+# ^ module
 #      ^ operator
 #       ^ function
 
 Kernel.-(number)
-# ^ type
+# ^ module
 #     ^ operator
 #      ^ operator
 #       ^ punctuation.bracket
@@ -59,7 +59,7 @@ Kernel.-(number)
 #              ^ punctuation.bracket
 
 Enum.map([1, 2], fn x ->
-# ^ type
+# ^ module
 #   ^ operator
 #    ^ function
 #       ^ punctuation.bracket
@@ -81,7 +81,7 @@ end)
 #  ^ punctuation.bracket
 
 :erlang.abs(-1)
-# ^ type
+# ^ module
 #      ^ operator
 #       ^ function
 #          ^ punctuation.bracket

--- a/test/highlight/data_structures.ex
+++ b/test/highlight/data_structures.ex
@@ -160,8 +160,8 @@
 
 %Long.Module.Name{name: "Silly"}
 # <- punctuation
-# ^ type
-#    ^ type
+# ^ module
+#    ^ module
 #                ^ punctuation.bracket
 #                 ^ string.special.symbol
 #                       ^ string
@@ -169,7 +169,7 @@
 
 %Long.Module.Name{s | height: {192, :cm}}
 # <- punctuation
-# ^ type
+# ^ module
 #                ^ punctuation.bracket
 #                 ^ variable
 #                   ^ operator
@@ -185,7 +185,7 @@
 # ^ string
 #   ^ punctuation.special
 #     ^ punctuation
-#      ^ type
+#      ^ module
 #                      ^ punctuation.bracket
 #                       ^ variable
 #                         ^ operator

--- a/test/highlight/identifiers.ex
+++ b/test/highlight/identifiers.ex
@@ -5,7 +5,7 @@ _018OP
 # ^ comment.unused
 
 A__0
-# ^ type
+# ^ module
 
 __MODULE__ ; __STACKTRACE__
 # ^ constant.builtin

--- a/test/highlight/kernel.ex
+++ b/test/highlight/kernel.ex
@@ -139,14 +139,14 @@ end
 
 raise RuntimeError, message: "This is not an error"
 # ^ keyword
-#     ^ type
+#     ^ module
 #                 ^ punctuation.delimiter
 #                   ^ string.special.symbol
 #                            ^ string
 
 import Kernel, except: [spawn: 1, +: 2, /: 2, Unless: 2]
 # ^ keyword
-#      ^ type
+#      ^ module
 #            ^ punctuation.delimiter
 #              ^ string.special.symbol
 #                      ^ punctuation.bracket
@@ -165,11 +165,11 @@ import Kernel, except: [spawn: 1, +: 2, /: 2, Unless: 2]
 
 alias Long.Module.Name, as: N0men123_and4
 # ^ keyword
-#     ^ type
+#     ^ module
 #                     ^ punctuation.delimiter
 #                       ^ string.special.symbol
-#                           ^ type
+#                           ^ module
 
 use Bitwise
 # ^ keyword
-#   ^ type
+#   ^ module

--- a/test/highlight/module.ex
+++ b/test/highlight/module.ex
@@ -1,7 +1,7 @@
 defmodule Long.Module.Name do
 # ^ keyword
-#         ^ type
-#             ^ type
+#         ^ module
+#             ^ module
 #                          ^ keyword
 
   @moduledoc "Simple doc"
@@ -80,7 +80,7 @@ defmodule Long.Module.Name do
   # ^ attribute
   #     ^ variable
   #          ^ operator
-  #             ^ type
+  #             ^ module
   #                   ^ operator
   #                    ^ function
   #                     ^ punctuation.bracket
@@ -256,7 +256,7 @@ defmodule Long.Module.Name do
   #                      ^ punctuation.bracket
   #                       ^ punctuation.delimiter
   #                         ^ string.special.symbol
-  #                             ^ type
+  #                             ^ module
 
   defmacro meta_function(name) do
   # ^ keyword
@@ -297,7 +297,7 @@ end
 
 defprotocol Useless do
 # ^ keyword
-#           ^ type
+#           ^ module
 #                   ^ keyword
   def func(this)
   # ^ keyword
@@ -310,10 +310,10 @@ end
 
 defimpl Useless, for: Atom do
 # ^ keyword
-#       ^ type
+#       ^ module
 #              ^ punctuation.delimiter
 #                ^ string.special.symbol
-#                     ^ type
+#                     ^ module
 #                           ^ keyword
 end
 # <- keyword

--- a/test/highlight/operators.ex
+++ b/test/highlight/operators.ex
@@ -75,10 +75,10 @@ y = true and false
 "hello" |> String.upcase |> String.downcase()
 # ^ string
 #       ^ operator
-#          ^ type
+#          ^ module
 #                ^ operator
 #                 ^ function
 #                        ^ operator
-#                           ^ type
+#                           ^ module
 #                                 ^ operator
 #                                  ^ function


### PR DESCRIPTION
See #15.

Updating the highlight token from `@type` to `@module`, so that module names get the expected color on GitHub.