### PR TITLE
Improve highlighting in basic IEx snippets

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -2,6 +2,29 @@
 
 ["when" "and" "or" "not" "in" "not in" "fn" "do" "end" "catch" "rescue" "after" "else"] @keyword
 
+; * the reserved words are not valid identifiers, but if the code
+;   is invalid and we find those, we also highlight them as keywords,
+;   for example in IEx snippets
+(
+  (identifier) @keyword
+  (#match? @keyword "^(when|and|or|not|in|not in|fn|do|end|catch|rescue|after|else)$")
+)
+
+; IEx prefix
+
+(binary_operator
+  left: [
+    (identifier) @comment.iex.__identifier__
+    (call
+      target: (identifier) @comment.iex.__identifier__
+      (arguments
+        "(" @comment.iex
+        (integer) @comment.iex
+        ")" @comment.iex))
+  ]
+  operator: ">" @comment.iex
+  (#match? @comment.iex.__identifier__ "^(iex|\.\.\.)$"))
+
 ; Operators
 
 ; * doc string

--- a/test/highlight/basic_iex_support.ex
+++ b/test/highlight/basic_iex_support.ex
@@ -1,0 +1,29 @@
+iex> case {1, 2, 3} do
+# <- comment.iex.__identifier__
+#  ^ comment.iex
+#    ^ keyword
+#          ^ number
+#                   ^ keyword
+...>   {4, 5, 6} ->
+# <- comment.iex.__identifier__
+#  ^ comment.iex
+#       ^ number
+#                ^ operator
+...>     "This clause won't match"
+# <- comment.iex.__identifier__
+#  ^ comment.iex
+#        ^ string
+...>   {1, x, 3} ->
+# <- comment.iex.__identifier__
+#  ^ comment.iex
+...>     "This clause will match and bind x to 2 in this clause"
+...>   _ ->
+# <- comment.iex.__identifier__
+#  ^ comment.iex
+...>     "This clause would match any value"
+...> end
+# <- comment.iex.__identifier__
+#  ^ comment.iex
+#    ^ keyword
+"This clause will match and bind x to 2 in this clause"
+# ^ string


### PR DESCRIPTION
Code with IEx snippets is usually not a valid Elixir syntax (as soon as we introduce blocks), however tree-sitter parses most of code just fine. Consequently, with a few rules we can significantly improve highlighting.

IEx snippets are mostly used in Markdown like this:

```elixir
iex(1)> if true do
...(1)>   1
...(1)> end
```

### Before

![image](https://user-images.githubusercontent.com/17034772/146544172-413aded5-5ba8-4cf6-aa71-af98b0362403.png)

![image](https://user-images.githubusercontent.com/17034772/146544198-23e4aa89-9b98-486a-9668-5ed97d212e52.png)

![image](https://user-images.githubusercontent.com/17034772/146544215-f742f87f-07cd-4302-bd74-62a2bcf93272.png)

### After

![image](https://user-images.githubusercontent.com/17034772/146544256-99f5459d-9f39-46e4-b3f6-90b9165f71a3.png)

![image](https://user-images.githubusercontent.com/17034772/146544284-76375c38-d75b-4233-a1c2-1050cbceb48b.png)

![image](https://user-images.githubusercontent.com/17034772/146544308-5f22addb-f84f-48bc-a921-623f9f606e04.png)

As seen on the last snippet, more complex (especially nested) code still has glitches, but that's expected given the syntax is invalid.

Currently the syntaxes above are invalid because `end` is parsed as identifier and the actual block end is missing. Once https://github.com/tree-sitter/tree-sitter/pull/246 is in place, we would be able to make sure reserved keywords are never parsed as identifiers, which would most likely make the blocks parse fine (the parsing error would be in a different node), and consequently the highlighting would also work for nested blocks.

---

@patrickt it would be neat if there was a token type that gets CSS `user-select: none;`, so that the code can be copied without the prefixes, like [here](https://hexdocs.pm/iex/IEx.html). Ruby has similar prefixes, so maybe it could be used there too. That said, this may be out of the scope given it is based on invalid syntax in the first place, but just throwing an idea :)

cc @maxbrunsfeld in case you have any thoughts regarding this use case