### PR TITLE
add tags.scm queries

### DIFF
--- a/queries/tags.scm
+++ b/queries/tags.scm
@@ -1,0 +1,66 @@
+; Definitions
+
+; * modules
+(call
+  target: (identifier) @ignore
+  (arguments (alias) @name)
+  (#eq? @ignore "defmodule")) @definition.module
+
+; * protocols
+(call
+  target: (identifier) @ignore
+  (arguments (alias) @name)
+  (#eq? @ignore "defprotocol")) @definition.interface
+
+; * implementations for protocols
+(call
+  target: (identifier) @ignore
+  (arguments (alias) @name)
+  (#eq? @ignore "defimpl")) @definition.implementation
+
+; * functions/macros
+(call
+  target: (identifier) @ignore
+  (arguments
+    [
+      ; zero-arity functions with no parentheses
+      (identifier) @name
+      ; regular function clause
+      (call target: (identifier) @name)
+      ; function clause with a guard clause
+      (binary_operator
+        left: (call target: (identifier) @name)
+        operator: "when")
+    ])
+  (#match? @ignore "^(def|defp|defdelegate|defguard|defguardp|defmacro|defmacrop|defn|defnp)$")) @definition.function
+
+; References
+
+; ignore calls to kernel/special-forms keywords
+(call
+  target: (identifier) @ignore
+  (#match? @ignore "^(def|defp|defdelegate|defguard|defguardp|defmacro|defmacrop|defn|defnp|defmodule|defprotocol|defimpl|defstruct|defexception|defoverridable|alias|case|cond|else|for|if|import|quote|raise|receive|require|reraise|super|throw|try|unless|unquote|unquote_splicing|use|with)$"))
+
+; ignore module attributes
+(unary_operator
+  operator: "@"
+  operand: (call
+    target: (identifier) @ignore))
+
+; * function call
+(call
+  target: [
+   ; local
+   (identifier) @name
+   ; remote
+   (dot
+     right: (identifier) @name)
+  ]) @reference.call
+
+; * pipe into function call
+(binary_operator
+  operator: "|>"
+  right: (identifier) @name) @reference.call
+
+; * modules
+(alias) @name @reference.call

--- a/queries/tags.scm
+++ b/queries/tags.scm
@@ -12,12 +12,6 @@
   (arguments (alias) @name)
   (#eq? @ignore "defprotocol")) @definition.interface
 
-; * implementations for protocols
-(call
-  target: (identifier) @ignore
-  (arguments (alias) @name)
-  (#eq? @ignore "defimpl")) @definition.implementation
-
 ; * functions/macros
 (call
   target: (identifier) @ignore
@@ -35,6 +29,12 @@
   (#match? @ignore "^(def|defp|defdelegate|defguard|defguardp|defmacro|defmacrop|defn|defnp)$")) @definition.function
 
 ; References
+
+; * implementations for protocols point to the defprotocol module
+(call
+  target: (identifier) @ignore
+  (arguments (alias) @name)
+  (#eq? @ignore "defimpl")) @reference.interface
 
 ; ignore calls to kernel/special-forms keywords
 (call

--- a/queries/tags.scm
+++ b/queries/tags.scm
@@ -63,4 +63,4 @@
   right: (identifier) @name) @reference.call
 
 ; * modules
-(alias) @name @reference.call
+(alias) @name @reference.module

--- a/queries/tags.scm
+++ b/queries/tags.scm
@@ -1,16 +1,10 @@
 ; Definitions
 
-; * modules
+; * modules and protocols
 (call
   target: (identifier) @ignore
   (arguments (alias) @name)
-  (#eq? @ignore "defmodule")) @definition.module
-
-; * protocols
-(call
-  target: (identifier) @ignore
-  (arguments (alias) @name)
-  (#eq? @ignore "defprotocol")) @definition.interface
+  (#match? @ignore "^(defmodule|defprotocol)$")) @definition.module
 
 ; * functions/macros
 (call
@@ -29,12 +23,6 @@
   (#match? @ignore "^(def|defp|defdelegate|defguard|defguardp|defmacro|defmacrop|defn|defnp)$")) @definition.function
 
 ; References
-
-; * implementations for protocols point to the defprotocol module
-(call
-  target: (identifier) @ignore
-  (arguments (alias) @name)
-  (#eq? @ignore "defimpl")) @reference.interface
 
 ; ignore calls to kernel/special-forms keywords
 (call


### PR DESCRIPTION
`tags.scm` powers [GitHub code navigation](https://docs.github.com/en/repositories/working-with-files/using-files/navigating-code-on-github) for languages that use tree-sitters.

<details><summary>For example with ruby...</summary>

You can see class/method declarations:

![ruby](https://user-images.githubusercontent.com/21230295/146465798-557badd8-c89f-4f1c-99e3-06e558779cc0.png)

And see the references (where those classes/methods end up being used):

![ruby](https://user-images.githubusercontent.com/21230295/146465889-61faa1b3-3bee-4e04-be30-194dae11cdc5.png)

<hr>

</details>

These queries ended up taking inspiration from other `tags.scm` in the `@tree-sitter` org repos, mostly [python](https://github.com/tree-sitter/tree-sitter-python/blob/master/queries/tags.scm) and [ruby](https://github.com/tree-sitter/tree-sitter-ruby/blob/master/queries/tags.scm).

~I don't think there's a framework in place for testing these queries, but I think it wouldn't be too much trouble to write a small shell script that diffs the output of `tree-sitter tags fixture.ex` against a known solution for some fixtures. There is the ability to test queries like so: `tree-sitter query --test query/tags.scm test/query/fixture.ex` (added in [`tree-sitter#775`](https://github.com/tree-sitter/tree-sitter/pull/775)) but the precedence rules seem to be backward between querying and determining tags (e.g. module/function definitions end up as `@reference.call`s in the query output but are correctly identified by `tree-sitter tags`). I can look at making a PR to tree-sitter that adds a flag for testing `tree-sitter tags` or maybe somehow reverses precedence in `tree-sitter query`.~ We should be able to use [tree-sitter#1547](https://github.com/tree-sitter/tree-sitter/pull/1547) to test these queries if/when merged.

A sample output of `tree-sitter tags path/to/mint/mix.exs` with [this](https://github.com/elixir-mint/mint/blob/1ea7731d921840ad75a47fa9415525c3d94b9980/mix.exs) Mint mix.exs:

```
Mint.MixProject	| module  	def (0, 10) - (0, 25) `defmodule Mint.MixProject do`
Mix.Project	| call    	ref (1, 6) - (1, 17) `use Mix.Project`
project   	| function	def (6, 6) - (6, 13) `def project do`
Mix       	| call    	ref (11, 23) - (11, 26) `start_permanent: Mix.env() == :prod,`
env       	| call    	ref (11, 27) - (11, 30) `start_permanent: Mix.env() == :prod,`
elixirc_paths	| call    	ref (12, 21) - (12, 34) `elixirc_paths: elixirc_paths(Mix.env()),`
Mix       	| call    	ref (12, 35) - (12, 38) `elixirc_paths: elixirc_paths(Mix.env()),`
env       	| call    	ref (12, 39) - (12, 42) `elixirc_paths: elixirc_paths(Mix.env()),`
deps      	| call    	ref (13, 12) - (13, 16) `deps: deps(),`
package   	| call    	ref (29, 15) - (29, 22) `package: package(),`
application	| function	def (46, 6) - (46, 17) `def application do`
Mint.Application	| call    	ref (49, 12) - (49, 28) `mod: {Mint.Application, []}`
package   	| function	def (53, 7) - (53, 14) `defp package do`
elixirc_paths	| function	def (60, 7) - (60, 20) `defp elixirc_paths(:test), do: ["lib", "test/support"]`
elixirc_paths	| function	def (61, 7) - (61, 20) `defp elixirc_paths(_env), do: ["lib"]`
deps      	| function	def (64, 7) - (64, 11) `defp deps do`
```

So the queries tag function/module definitions and usages of functions/modules. It's notable that modules are tagged as `@reference.call` when not being `defmodule`d: this lines up with the behavior of the ruby queries and allows you to jump to definitions of modules, it's not saying that those modules are function invocations. These queries aren't smart enough to figure out some language semantics like resolving `alias`ed modules. For "precise navigation" which respects language semantics, we'd need to write some stack-graph construction queries (see [this blog post](https://github.blog/2021-12-09-introducing-stack-graphs/)), but stack-graphs are very new and it may be wise to wait until they're matured. Also the python queries aren't open-sourced afaict so I haven't really figured out the tricks yet 😅. Once I figure all that out, I'll try sending in some stack-graphs queries :)

@patrickt is this something I can trouble you with setting up if/once it's merged in (and maybe lend some review eyes)? I appreciate all your help with the integration stuff :)
