### PR TITLE
Fix multiline stab clause with trailing identifier

### DIFF
--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4791,24 +4791,46 @@
       ]
     },
     "_call_arguments_without_parentheses": {
-      "type": "PREC_RIGHT",
-      "value": 0,
+      "type": "PREC_DYNAMIC",
+      "value": -1,
       "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "_expression"
-                  },
-                  {
-                    "type": "REPEAT",
-                    "content": {
+        "type": "PREC_RIGHT",
+        "value": 0,
+        "content": {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_expression"
+                    },
+                    {
+                      "type": "REPEAT",
+                      "content": {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": ","
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "_expression"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
                       "type": "SEQ",
                       "members": [
                         {
@@ -4817,41 +4839,23 @@
                         },
                         {
                           "type": "SYMBOL",
-                          "name": "_expression"
+                          "name": "keywords"
                         }
                       ]
+                    },
+                    {
+                      "type": "BLANK"
                     }
-                  }
-                ]
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": ","
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "keywords"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "type": "SYMBOL",
-            "name": "keywords"
-          }
-        ]
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "SYMBOL",
+              "name": "keywords"
+            }
+          ]
+        }
       }
     },
     "do_block": {

--- a/test/corpus/do_end.txt
+++ b/test/corpus/do_end.txt
@@ -575,6 +575,114 @@ fun do->end
     (do_block
       (stab_clause))))
 
+
+=====================================
+stab clause / edge cases / trailing call in multiline clause
+=====================================
+
+fun do
+  1 ->
+    1
+    x
+
+  1 ->
+    1
+end
+
+fun do
+  1 ->
+    1
+    Mod.fun
+
+  1 ->
+    1
+end
+
+fun do
+  1 ->
+    1
+    mod.fun
+
+  1 ->
+    1
+end
+
+fun do
+  1 ->
+    1
+
+  x 1 ->
+    1
+end
+
+---
+
+(source
+  (call
+    (identifier)
+    (do_block
+      (stab_clause
+        (arguments
+          (integer))
+        (body
+          (integer)
+          (identifier)))
+      (stab_clause
+        (arguments
+          (integer))
+        (body
+          (integer)))))
+  (call
+    (identifier)
+    (do_block
+      (stab_clause
+        (arguments
+          (integer))
+        (body
+          (integer)
+          (call
+            (dot
+              (alias)
+              (identifier)))))
+      (stab_clause
+        (arguments
+          (integer))
+        (body
+          (integer)))))
+  (call
+    (identifier)
+    (do_block
+      (stab_clause
+        (arguments
+          (integer))
+        (body
+          (integer)
+          (call
+            (dot
+              (identifier)
+              (identifier)))))
+      (stab_clause
+        (arguments
+          (integer))
+        (body
+          (integer)))))
+  (call
+    (identifier)
+    (do_block
+      (stab_clause
+        (arguments
+          (integer))
+        (body
+          (integer)))
+      (stab_clause
+        (arguments
+          (call
+            (identifier)
+            (arguments
+              (integer))))
+        (body
+          (integer))))))
+
 =====================================
 pattern matching
 =====================================


### PR DESCRIPTION
Fixes an edge case where

```elixir
fun do
  x ->
    x
    x

  1 ->
    x
end
```

would be interpreted as

```elixir
fun do
  x ->
    x
  
  x 1 ->
    x
end
```

(which manifests itself in the highlighting)