### PR TITLE
bump tree-sitter-cli version to v0.20.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "tree-sitter-elixir",
       "version": "0.19.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -12,7 +13,7 @@
       },
       "devDependencies": {
         "prettier": "^2.3.2",
-        "tree-sitter-cli": "^0.19.5"
+        "tree-sitter-cli": "^0.20.1"
       }
     },
     "node_modules/nan": {
@@ -33,9 +34,9 @@
       }
     },
     "node_modules/tree-sitter-cli": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.19.5.tgz",
-      "integrity": "sha512-kRzKrUAwpDN9AjA3b0tPBwT1hd8N2oQvvvHup2OEsX6mdsSMLmAvR+NSqK9fe05JrRbVvG8mbteNUQsxlMQohQ==",
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.20.1.tgz",
+      "integrity": "sha512-I0Gp4ThRp39TDnBAaZKiogvoE85MSeL6/ILZMXbzeEo8hUsudpVhEHRE4CU+Bk5QUaiMiDkD+ZIL3gT2zZ++wg==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -56,9 +57,9 @@
       "dev": true
     },
     "tree-sitter-cli": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.19.5.tgz",
-      "integrity": "sha512-kRzKrUAwpDN9AjA3b0tPBwT1hd8N2oQvvvHup2OEsX6mdsSMLmAvR+NSqK9fe05JrRbVvG8mbteNUQsxlMQohQ==",
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.20.1.tgz",
+      "integrity": "sha512-I0Gp4ThRp39TDnBAaZKiogvoE85MSeL6/ILZMXbzeEo8hUsudpVhEHRE4CU+Bk5QUaiMiDkD+ZIL3gT2zZ++wg==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "prettier": "^2.3.2",
-    "tree-sitter-cli": "^0.19.5"
+    "tree-sitter-cli": "^0.20.1"
   },
   "tree-sitter": [
     {


### PR DESCRIPTION
I think this should resolve the [failing generate workflow](https://github.com/elixir-lang/tree-sitter-elixir/runs/4764124334?check_suite_focus=true), the workflow I have in tree-sitter-git-commit is just about the same but I have tree-sitter-cli bumped up to v0.20.1