### PR TITLE
add unit tests for tags.scm queries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "prettier": "^2.3.2",
-        "tree-sitter-cli": "^0.20.1"
+        "tree-sitter-cli": "^0.20.6"
       }
     },
     "node_modules/nan": {
@@ -34,9 +34,9 @@
       }
     },
     "node_modules/tree-sitter-cli": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.20.1.tgz",
-      "integrity": "sha512-I0Gp4ThRp39TDnBAaZKiogvoE85MSeL6/ILZMXbzeEo8hUsudpVhEHRE4CU+Bk5QUaiMiDkD+ZIL3gT2zZ++wg==",
+      "version": "0.20.6",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.20.6.tgz",
+      "integrity": "sha512-tjbAeuGSMhco/EnsThjWkQbDIYMDmdkWsTPsa/NJAW7bjaki9P7oM9TkLxfdlnm4LXd1wR5wVSM2/RTLtZbm6A==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -57,9 +57,9 @@
       "dev": true
     },
     "tree-sitter-cli": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.20.1.tgz",
-      "integrity": "sha512-I0Gp4ThRp39TDnBAaZKiogvoE85MSeL6/ILZMXbzeEo8hUsudpVhEHRE4CU+Bk5QUaiMiDkD+ZIL3gT2zZ++wg==",
+      "version": "0.20.6",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.20.6.tgz",
+      "integrity": "sha512-tjbAeuGSMhco/EnsThjWkQbDIYMDmdkWsTPsa/NJAW7bjaki9P7oM9TkLxfdlnm4LXd1wR5wVSM2/RTLtZbm6A==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "prettier": "^2.3.2",
-    "tree-sitter-cli": "^0.20.1"
+    "tree-sitter-cli": "^0.20.6"
   },
   "tree-sitter": [
     {

--- a/test/tags/module.ex
+++ b/test/tags/module.ex
@@ -1,0 +1,31 @@
+defmodule Foo.Bar.Baz do
+  #        ^ definition.module
+  #            ^ definition.module
+  #                ^ definition.module
+
+  def init(arg) do
+    #  ^ definition.function
+    state =
+      arg
+      |> map(&(&1 * 2))
+      #   ^ reference.call
+      |> map(&(&1 + 1))
+      #   ^ reference.call
+
+    {:ok, arg}
+  end
+
+  def map(list, fun, acc \\ [])
+  #    ^ definition.function
+
+  def map([head | rest], fun, acc) do
+    #  ^ definition.function
+    map(rest, fun, [fun.(head) | acc])
+    # <- reference.call
+  end
+
+  def map([], _fun, acc), do: Enum.reverse(acc)
+  #    ^ definition.function
+  #                             ^ reference.module
+  #                                    ^ reference.call
+end

--- a/test/tags/protocol.ex
+++ b/test/tags/protocol.ex
@@ -1,0 +1,21 @@
+defprotocol Countable do
+  #          ^ definition.module
+  def count(data)
+  #    ^ definition.function
+end
+
+defimpl Countable, for: Binary do
+  #      ^ reference.module
+  #                      ^ reference.module
+  def count(binary), do: byte_size(binary)
+  #    ^ definition.function
+  #                       ^ reference.call
+end
+
+defimpl Countable, for: List do
+  #      ^ reference.module
+  #                      ^ reference.module
+  def count(list), do: length(list)
+  #    ^ definition.function
+  #                     ^ reference.call
+end


### PR DESCRIPTION
tree-sitter v0.20.6 was just published and it adds a [testing mechanism for tags queries](https://github.com/tree-sitter/tree-sitter/pull/1547) very similar to how the highlights tests work, except it's `test/tags/*` instead of `test/highlight/*`.

So here I have a fixture module from Mint with the tags tests. Should we add some more tests? I can't think of any edge-cases off the top of my head that would be interesting to test, but the more the merrier IMO 😄