### PR TITLE
Ignore heredoc end delimiter unless in a new line

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -888,11 +888,11 @@ function defineQuoted(start, end, name) {
     [`_quoted_i_${name}`]: ($) =>
       seq(
         field("quoted_start", start),
+        optional(alias($[`_quoted_content_i_${name}`], $.quoted_content)),
         repeat(
-          choice(
-            alias($[`_quoted_content_i_${name}`], $.quoted_content),
-            $.interpolation,
-            $.escape_sequence
+          seq(
+            choice($.interpolation, $.escape_sequence),
+            optional(alias($[`_quoted_content_i_${name}`], $.quoted_content))
           )
         ),
         field("quoted_end", end)
@@ -901,11 +901,12 @@ function defineQuoted(start, end, name) {
     [`_quoted_${name}`]: ($) =>
       seq(
         field("quoted_start", start),
+        optional(alias($[`_quoted_content_${name}`], $.quoted_content)),
         repeat(
-          choice(
-            alias($[`_quoted_content_${name}`], $.quoted_content),
-            // The end delimiter may always be escaped
-            $.escape_sequence
+          seq(
+            // The end delimiter may be escaped in non-interpolating strings too
+            $.escape_sequence,
+            optional(alias($[`_quoted_content_${name}`], $.quoted_content))
           )
         ),
         field("quoted_end", end)

--- a/test/corpus/term/string.txt
+++ b/test/corpus/term/string.txt
@@ -1,4 +1,15 @@
 =====================================
+empty
+=====================================
+
+""
+
+---
+
+(source
+  (string))
+
+=====================================
 single line
 =====================================
 
@@ -169,6 +180,47 @@ this is #{
         (interpolation
           (integer))
         (quoted_content)))
+    (quoted_content)))
+
+=====================================
+heredoc / delimiter in the middle
+=====================================
+
+"""
+hey """
+"""
+
+---
+
+(source
+  (string
+    (quoted_content)))
+
+=====================================
+heredoc / escaped newline (ignored)
+=====================================
+
+"""
+hey \
+"""
+
+  """
+  hey \
+  """
+
+"""
+hey \
+there
+"""
+
+---
+
+(source
+  (string
+    (quoted_content))
+  (string
+    (quoted_content))
+  (string
     (quoted_content)))
 
 =====================================


### PR DESCRIPTION
Given

```
"""
hey """
"""
```

we currently treat the second `"""` as end delimiter, which is not correct.

This PR essentially adds a constraint, such that when parsing heredoc content, we recognise end delimiter only when it goes in a new line (with optional leading whitespace).

As a side effect, we now don't distinguish escaped newlines (`\<enter>`) inside heredocs, otherwise we wouldn't treat `\<enter>"""` as end delimiter. I tried a number of things and I don't see any solution with reasonable complexity. In practice this means we won't highlight `\` in this particular case, which seems fine to me.