### PR TITLE
Add HEEx language injection for `~H` sigils

### DIFF
--- a/queries/injections.scm
+++ b/queries/injections.scm
@@ -1,0 +1,7 @@
+; Phoenix Live View
+((sigil
+  (sigil_name) @_sigil_name
+  (quoted_content) @injection.content)
+ (#eq @_sigil_name "H")
+ (#set! injection.language "heex")
+ (#set! injection.combined))

--- a/queries/injections.scm
+++ b/queries/injections.scm
@@ -1,4 +1,4 @@
-; Phoenix Live View
+; Phoenix HTML template
 ((sigil
   (sigil_name) @_sigil_name
   (quoted_content) @injection.content)


### PR DESCRIPTION
See https://github.com/elixir-lang/tree-sitter-elixir/issues/2 and https://github.com/connorlay/tree-sitter-heex/pull/11

This PR adds tree-sitter-heex language injection into `~H` sigils provided by Phoenix Live View.

Here is an example of syntax highlighting of https://github.com/fly-apps/live_beats/blob/master/lib/live_beats_web/live/layout_component.ex:
![image](https://user-images.githubusercontent.com/6548350/163724525-19f1950c-cfcb-4536-9f1b-76cfd85c5d12.png)
