### PR TITLE
Bump to tree-sitter 0.20.7 and regenerate parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "prettier": "^2.3.2",
-        "tree-sitter-cli": "^0.20.6"
+        "tree-sitter-cli": "^0.20.7"
       }
     },
     "node_modules/nan": {
@@ -34,9 +34,9 @@
       }
     },
     "node_modules/tree-sitter-cli": {
-      "version": "0.20.6",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.20.6.tgz",
-      "integrity": "sha512-tjbAeuGSMhco/EnsThjWkQbDIYMDmdkWsTPsa/NJAW7bjaki9P7oM9TkLxfdlnm4LXd1wR5wVSM2/RTLtZbm6A==",
+      "version": "0.20.7",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.20.7.tgz",
+      "integrity": "sha512-MHABT8oCPr4D0fatsPo6ATQ9H4h9vHpPRjlxkxJs80tpfAEKGn6A1zU3eqfCKBcgmfZDe9CiL3rKOGMzYHwA3w==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -57,9 +57,9 @@
       "dev": true
     },
     "tree-sitter-cli": {
-      "version": "0.20.6",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.20.6.tgz",
-      "integrity": "sha512-tjbAeuGSMhco/EnsThjWkQbDIYMDmdkWsTPsa/NJAW7bjaki9P7oM9TkLxfdlnm4LXd1wR5wVSM2/RTLtZbm6A==",
+      "version": "0.20.7",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.20.7.tgz",
+      "integrity": "sha512-MHABT8oCPr4D0fatsPo6ATQ9H4h9vHpPRjlxkxJs80tpfAEKGn6A1zU3eqfCKBcgmfZDe9CiL3rKOGMzYHwA3w==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "prettier": "^2.3.2",
-    "tree-sitter-cli": "^0.20.6"
+    "tree-sitter-cli": "^0.20.7"
   },
   "tree-sitter": [
     {


### PR DESCRIPTION
Upgrading to tree-sitter 0.20.7 causes the parser to be generated for the newest ABI version 14. This includes noticeable performance improvements when parsing query files for languages like Elixir using the new `primary_state_ids` field.

See https://github.com/tree-sitter/tree-sitter/pull/1589 and https://github.com/tree-sitter/tree-sitter/pull/1852 for more information on this change.

You can see the impact of this change by comparing how long it takes to execute `npm test` on this branch compared to `master` 🙂 This change should improve the initial load time of Elixir buffers in editors like Neovim and Helix that use tree-sitter-elixir for syntax highlighting.