### PR TITLE
docs: update cargo.toml to reflect current repository url

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "Elixir grammar for the tree-sitter parsing library"
 version = "0.1.0"
 keywords = ["incremental", "parsing", "elixir"]
 categories = ["parsing", "text-editors"]
-repository = "https://github.com/tree-sitter/tree-sitter-elixir"
+repository = "https://github.com/elixir-lang/tree-sitter-elixir"
 edition = "2018"
 license = "Apache-2.0"
 


### PR DESCRIPTION
👋🏻 hey there
we've got reported an incorrect url on our generated license attribution, and it seems that the cargo.toml file in this project is pointing to a non-existing url, which is what's being pulled when gathering this info