### PR TITLE
Fix rust binding build script

### DIFF
--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -9,8 +9,11 @@ fn main() {
         .flag_if_supported("-Wno-trigraphs");
     let parser_path = src_dir.join("parser.c");
     c_config.file(&parser_path);
+    println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
 
     let scanner_path = src_dir.join("scanner.c");
     c_config.file(&scanner_path);
     println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
+
+    c_config.compile("parser-scanner");
 }


### PR DESCRIPTION
Closes #58

It looks like #56 mistakenly removed `cc::Build::compile`. I also added a `rerun-if-changed` for the parser so that changes to the grammar would cause cargo to recompile the parser.

Also see the tree-sitter-rust builder: https://github.com/tree-sitter/tree-sitter-rust/blob/master/bindings/rust/build.rs.