### PR TITLE
Update to tree-sitter 0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-elixir"
 description = "Elixir grammar for the tree-sitter parsing library"
-version = "0.2.0"
+version = "0.3.0"
 keywords = ["incremental", "parsing", "elixir"]
 categories = ["parsing", "text-editors"]
 repository = "https://github.com/elixir-lang/tree-sitter-elixir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,10 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = ">=0.21.0"
+tree-sitter-language = "0.1.0"
+
+[dev-dependencies]
+tree-sitter = "0.23.0"
 
 [build-dependencies]
 cc = "1.0"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 0.2.0
+VERSION := 0.3.0
 
 # Repository
 SRC_DIR := src

--- a/bindings/go/binding_test.go
+++ b/bindings/go/binding_test.go
@@ -3,8 +3,8 @@ package tree_sitter_elixir_test
 import (
 	"testing"
 
-	tree_sitter "github.com/smacker/go-tree-sitter"
-	"github.com/tree-sitter/tree-sitter-elixir"
+	tree_sitter "github.com/tree-sitter/go-tree-sitter"
+	tree_sitter_elixir "github.com/tree-sitter/tree-sitter-elixir/bindings/go"
 )
 
 func TestCanLoadGrammar(t *testing.T) {

--- a/bindings/go/go.mod
+++ b/bindings/go/go.mod
@@ -1,5 +1,0 @@
-module github.com/tree-sitter/tree-sitter-elixir
-
-go 1.22
-
-require github.com/smacker/go-tree-sitter v0.0.0-20230720070738-0d0a9f78d8f8

--- a/bindings/node/binding_test.js
+++ b/bindings/node/binding_test.js
@@ -1,0 +1,9 @@
+/// <reference types="node" />
+
+const assert = require("node:assert");
+const { test } = require("node:test");
+
+test("can load grammar", () => {
+  const parser = new (require("tree-sitter"))();
+  assert.doesNotThrow(() => parser.setLanguage(require(".")));
+});

--- a/bindings/python/tests/test_binding.py
+++ b/bindings/python/tests/test_binding.py
@@ -1,0 +1,11 @@
+from unittest import TestCase
+
+import tree_sitter, tree_sitter_elixir
+
+
+class TestLanguage(TestCase):
+    def test_can_load_grammar(self):
+        try:
+            tree_sitter.Language(tree_sitter_elixir.language())
+        except Exception:
+            self.fail("Error loading Elixir grammar")

--- a/bindings/python/tree_sitter_elixir/binding.c
+++ b/bindings/python/tree_sitter_elixir/binding.c
@@ -4,8 +4,8 @@ typedef struct TSLanguage TSLanguage;
 
 TSLanguage *tree_sitter_elixir(void);
 
-static PyObject* _binding_language(PyObject *self, PyObject *args) {
-    return PyLong_FromVoidPtr(tree_sitter_elixir());
+static PyObject* _binding_language(PyObject *Py_UNUSED(self), PyObject *Py_UNUSED(args)) {
+    return PyCapsule_New(tree_sitter_elixir(), "tree_sitter.Language", NULL);
 }
 
 static PyMethodDef methods[] = {

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -7,6 +7,9 @@ fn main() {
         .flag_if_supported("-Wno-unused-parameter")
         .flag_if_supported("-Wno-unused-but-set-variable")
         .flag_if_supported("-Wno-trigraphs");
+    #[cfg(target_env = "msvc")]
+    c_config.flag("-utf-8");
+
     let parser_path = src_dir.join("parser.c");
     c_config.file(&parser_path);
     println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -1,13 +1,18 @@
-//! This crate provides elixir language support for the [tree-sitter][] parsing library.
+//! This crate provides Elixir language support for the [tree-sitter][] parsing library.
 //!
 //! Typically, you will use the [language][language func] function to add this language to a
 //! tree-sitter [Parser][], and then use the parser to parse some code:
 //!
 //! ```
-//! let code = "";
+//! let code = r#"
+//! "#;
 //! let mut parser = tree_sitter::Parser::new();
-//! parser.set_language(tree_sitter_elixir::language()).expect("Error loading elixir grammar");
+//! let language = tree_sitter_elixir::LANGUAGE;
+//! parser
+//!     .set_language(&language.into())
+//!     .expect("Error loading Elixir parser");
 //! let tree = parser.parse(code, None).unwrap();
+//! assert!(!tree.root_node().has_error());
 //! ```
 //!
 //! [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
@@ -15,30 +20,26 @@
 //! [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
 //! [tree-sitter]: https://tree-sitter.github.io/
 
-use tree_sitter::Language;
+use tree_sitter_language::LanguageFn;
 
 extern "C" {
-    fn tree_sitter_elixir() -> Language;
+    fn tree_sitter_elixir() -> *const ();
 }
 
-/// Get the tree-sitter [Language][] for this grammar.
-///
-/// [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
-pub fn language() -> Language {
-    unsafe { tree_sitter_elixir() }
-}
+/// The tree-sitter [`LanguageFn`] for this grammar.
+pub const LANGUAGE: LanguageFn = unsafe { LanguageFn::from_raw(tree_sitter_elixir) };
 
 /// The content of the [`node-types.json`][] file for this grammar.
 ///
 /// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types
-pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
+pub const NODE_TYPES: &str = include_str!("../../src/node-types.json");
 
-// Uncomment these to include any queries that this grammar contains
+// NOTE: uncomment these to include any queries that this grammar contains:
 
-pub const HIGHLIGHTS_QUERY: &'static str = include_str!("../../queries/highlights.scm");
-// pub const INJECTIONS_QUERY: &'static str = include_str!("../../queries/injections.scm");
-// pub const LOCALS_QUERY: &'static str = include_str!("../../queries/locals.scm");
-pub const TAGS_QUERY: &'static str = include_str!("../../queries/tags.scm");
+pub const HIGHLIGHTS_QUERY: &str = include_str!("../../queries/highlights.scm");
+pub const INJECTIONS_QUERY: &str = include_str!("../../queries/injections.scm");
+// pub const LOCALS_QUERY: &str = include_str!("../../queries/locals.scm");
+pub const TAGS_QUERY: &str = include_str!("../../queries/tags.scm");
 
 #[cfg(test)]
 mod tests {
@@ -46,7 +47,7 @@ mod tests {
     fn test_can_load_grammar() {
         let mut parser = tree_sitter::Parser::new();
         parser
-            .set_language(super::language())
-            .expect("Error loading elixir language");
+            .set_language(&super::LANGUAGE.into())
+            .expect("Error loading Elixir parser");
     }
 }

--- a/bindings/swift/TreeSitterElixirTests/TreeSitterElixirTests.swift
+++ b/bindings/swift/TreeSitterElixirTests/TreeSitterElixirTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+import SwiftTreeSitter
+import TreeSitterElixir
+
+final class TreeSitterElixirTests: XCTestCase {
+    func testCanLoadGrammar() throws {
+        let parser = Parser()
+        let language = Language(language: tree_sitter_elixir())
+        XCTAssertNoThrow(try parser.setLanguage(language),
+                         "Error loading Elixir grammar")
+    }
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/tree-sitter/tree-sitter-elixir
+
+go 1.23
+
+require github.com/tree-sitter/go-tree-sitter v0.23

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tree-sitter-elixir",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tree-sitter-elixir",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -17,7 +17,7 @@
         "clang-format": "^1.8.0",
         "prebuildify": "^6.0.0",
         "prettier": "^2.3.2",
-        "tree-sitter-cli": "^0.22.2"
+        "tree-sitter-cli": "^0.23.0"
       },
       "peerDependencies": {
         "tree-sitter": "^0.21.0"
@@ -525,13 +525,17 @@
       }
     },
     "node_modules/tree-sitter-cli": {
-      "version": "0.22.2",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.22.2.tgz",
-      "integrity": "sha512-ecqccEp27XMFXgjLMEEU71vK9JCWAC7fqSTTxcs5P1tnEnaaf4GkHz/wfo4lJ9l3rfxcTDPxN84tHAoitIQqdA==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.23.0.tgz",
+      "integrity": "sha512-/DdQaPCCOrOYGp9FxGdhFUnHIrjhfbYatQXgNIcmaAOpPunpnDj2vsO/H+svsfQLaFsQ1C+BjgPhpbV28zka1w==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "bin": {
         "tree-sitter": "cli.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/tree-sitter/node_modules/node-addon-api": {
@@ -943,9 +947,9 @@
       }
     },
     "tree-sitter-cli": {
-      "version": "0.22.2",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.22.2.tgz",
-      "integrity": "sha512-ecqccEp27XMFXgjLMEEU71vK9JCWAC7fqSTTxcs5P1tnEnaaf4GkHz/wfo4lJ9l3rfxcTDPxN84tHAoitIQqdA==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.23.0.tgz",
+      "integrity": "sha512-/DdQaPCCOrOYGp9FxGdhFUnHIrjhfbYatQXgNIcmaAOpPunpnDj2vsO/H+svsfQLaFsQ1C+BjgPhpbV28zka1w==",
       "dev": true
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,15 @@
 {
   "name": "tree-sitter-elixir",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Elixir grammar for the tree-sitter parsing library",
   "main": "bindings/node",
   "types": "bindings/node",
-  "keywords": ["parser", "lexer", "elixir", "tree-sitter"],
+  "keywords": [
+    "parser",
+    "lexer",
+    "elixir",
+    "tree-sitter"
+  ],
   "files": [
     "grammar.js",
     "binding.gyp",
@@ -19,7 +24,8 @@
     "url": "https://github.com/elixir-lang/tree-sitter-elixir.git"
   },
   "scripts": {
-    "test": "tree-sitter test",
+    "build": "npx tree-sitter-cli generate --no-bindings",
+    "test": "npx tree-sitter-cli test",
     "format": "prettier --trailing-comma es5 --write grammar.js && clang-format -i src/scanner.c",
     "format-check": "prettier --trailing-comma es5 --check grammar.js && cat src/scanner.c | clang-format src/scanner.c | diff src/scanner.c -",
     "install": "node-gyp-build",
@@ -36,7 +42,7 @@
     "prebuildify": "^6.0.0"
   },
   "peerDependencies": {
-    "tree-sitter": "^0.21.0"
+    "tree-sitter": "^0.23.0"
   },
   "tree-sitter": [
     {

--- a/package.json
+++ b/package.json
@@ -38,11 +38,11 @@
   "devDependencies": {
     "clang-format": "^1.8.0",
     "prettier": "^2.3.2",
-    "tree-sitter-cli": "^0.22.2",
+    "tree-sitter-cli": "^0.23.0",
     "prebuildify": "^6.0.0"
   },
   "peerDependencies": {
-    "tree-sitter": "^0.23.0"
+    "tree-sitter": "^0.21.0"
   },
   "tree-sitter": [
     {


### PR DESCRIPTION
Tree-sitter released version 0.23 recently. This contains a breaking, but ultimately very good change to how parser bindings work (https://github.com/tree-sitter/tree-sitter/pull/3069). The TLDR of that change is that parsers do not depend on tree-sitter anymore, but instead on a shard (and supposedly very stable) tree-sitter-language crate. As a result, clients are free to chose their tree-sitter version as the parser ABI is supported. Library and parser versions are less tighly coupled, and it should no longer be necessary to move all the parsers to the next tree-sitter version in lock-step to be able to upgrade the library.

Most of the changes in this PR are from running tree-sitter generate. I'll add comments on other changes I did to explain why I thought they are necessary, or where I'm not sure I did it correctly.