### PR TITLE
Move parser information to tree-sitter.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "clang-format": "^1.8.0",
         "prebuildify": "^6.0.0",
         "prettier": "^2.3.2",
-        "tree-sitter-cli": "^0.23.0"
+        "tree-sitter-cli": "^0.24.0"
       },
       "peerDependencies": {
         "tree-sitter": "^0.21.0"
@@ -525,9 +525,9 @@
       }
     },
     "node_modules/tree-sitter-cli": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.23.0.tgz",
-      "integrity": "sha512-/DdQaPCCOrOYGp9FxGdhFUnHIrjhfbYatQXgNIcmaAOpPunpnDj2vsO/H+svsfQLaFsQ1C+BjgPhpbV28zka1w==",
+      "version": "0.24.4",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.24.4.tgz",
+      "integrity": "sha512-I4sdtDidnujYL0tR0Re9q0UJt5KrITf2m+GMHjT4LH6IC6kpM6eLzSR7RS36Z4t5ZQBjDHvg2QUJHAWQi3P2TA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -947,9 +947,9 @@
       }
     },
     "tree-sitter-cli": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.23.0.tgz",
-      "integrity": "sha512-/DdQaPCCOrOYGp9FxGdhFUnHIrjhfbYatQXgNIcmaAOpPunpnDj2vsO/H+svsfQLaFsQ1C+BjgPhpbV28zka1w==",
+      "version": "0.24.4",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.24.4.tgz",
+      "integrity": "sha512-I4sdtDidnujYL0tR0Re9q0UJt5KrITf2m+GMHjT4LH6IC6kpM6eLzSR7RS36Z4t5ZQBjDHvg2QUJHAWQi3P2TA==",
       "dev": true
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "clang-format": "^1.8.0",
     "prettier": "^2.3.2",
-    "tree-sitter-cli": "^0.23.0",
+    "tree-sitter-cli": "^0.24.0",
     "prebuildify": "^6.0.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,12 +24,13 @@
     "url": "https://github.com/elixir-lang/tree-sitter-elixir.git"
   },
   "scripts": {
-    "build": "tree-sitter generate --no-bindings",
+    "build": "tree-sitter generate",
     "test": "tree-sitter test",
     "format": "prettier --trailing-comma es5 --write grammar.js && clang-format -i src/scanner.c",
     "format-check": "prettier --trailing-comma es5 --check grammar.js && cat src/scanner.c | clang-format src/scanner.c | diff src/scanner.c -",
     "install": "node-gyp-build",
-    "prebuildify": "prebuildify --napi --strip"
+    "prestart": "tree-sitter build --wasm",
+    "start": "tree-sitter playground"
   },
   "dependencies": {
     "node-addon-api": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -43,14 +43,5 @@
   },
   "peerDependencies": {
     "tree-sitter": "^0.21.0"
-  },
-  "tree-sitter": [
-    {
-      "scope": "source.elixir",
-      "file-types": ["ex", "exs"],
-      "highlights": ["queries/highlights.scm"],
-      "tags": ["queries/tags.scm"],
-      "injection-regex": "^(ex|elixir)$"
-    }
-  ]
+  }
 }

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -1,0 +1,40 @@
+{
+  "grammars": [
+    {
+      "name": "elixir",
+      "camelcase": "Elixir",
+      "scope": "source.elixir",
+      "path": ".",
+      "file-types": ["ex", "exs"],
+      "highlights": "queries/highlights.scm",
+      "tags": "queries/tags.scm",
+      "injection-regex": "^(ex|elixir)$"
+    }
+  ],
+  "metadata": {
+    "version": "0.3.2",
+    "license": "Apache-2.0",
+    "description": "Elixir grammar for the tree-sitter parsing library",
+    "authors": [
+      {
+        "name": "Jonatan Kłosko",
+        "email": "jonatanklosko@gmail.com"
+      },
+      {
+        "name": "Michael Davis",
+        "email": "mcarsondavis@gmail.com"
+      }
+    ],
+    "links": {
+      "repository": "https://github.com/elixir-lang/tree-sitter-elixir"
+    }
+  },
+  "bindings": {
+    "c": true,
+    "go": true,
+    "node": true,
+    "python": true,
+    "rust": true,
+    "swift": true
+  }
+}


### PR DESCRIPTION
I noticed that calling TS globally as `npx tree-sitter-cli highlight /path/to/file` no longer respects the repo and I discovered there's a new file to store the parser metadata.