### PR TITLE
Prefer `#any-of?` predicate over `#match?` with alternation

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -48,7 +48,7 @@
 ; * special
 (
   (identifier) @constant.builtin
-  (#match? @constant.builtin "^(__MODULE__|__DIR__|__ENV__|__CALLER__|__STACKTRACE__)$")
+  (#any-of? @constant.builtin "__MODULE__" "__DIR__" "__ENV__" "__CALLER__" "__STACKTRACE__")
 )
 
 ; Comment
@@ -122,12 +122,12 @@
 ; * definition keyword
 (call
   target: (identifier) @keyword
-  (#match? @keyword "^(def|defdelegate|defexception|defguard|defguardp|defimpl|defmacro|defmacrop|defmodule|defn|defnp|defoverridable|defp|defprotocol|defstruct)$"))
+  (#any-of? @keyword "def" "defdelegate" "defexception" "defguard" "defguardp" "defimpl" "defmacro" "defmacrop" "defmodule" "defn" "defnp" "defoverridable" "defp" "defprotocol" "defstruct"))
 
 ; * kernel or special forms keyword
 (call
   target: (identifier) @keyword
-  (#match? @keyword "^(alias|case|cond|for|if|import|quote|raise|receive|require|reraise|super|throw|try|unless|unquote|unquote_splicing|use|with)$"))
+  (#any-of? @keyword "alias" "case" "cond" "for" "if" "import" "quote" "raise" "receive" "require" "reraise" "super" "throw" "try" "unless" "unquote" "unquote_splicing" "use" "with"))
 
 ; * just identifier in function definition
 (call
@@ -139,7 +139,7 @@
         left: (identifier) @function
         operator: "when")
     ])
-  (#match? @keyword "^(def|defdelegate|defguard|defguardp|defmacro|defmacrop|defn|defnp|defp)$"))
+  (#any-of? @keyword "def" "defdelegate" "defguard" "defguardp" "defmacro" "defmacrop" "defn" "defnp" "defp"))
 
 ; * pipe into identifier (function call)
 (binary_operator
@@ -153,7 +153,7 @@
     (binary_operator
       operator: "|>"
       right: (identifier) @variable))
-  (#match? @keyword "^(def|defdelegate|defguard|defguardp|defmacro|defmacrop|defn|defnp|defp)$"))
+  (#any-of? @keyword "def" "defdelegate" "defguard" "defguardp" "defmacro" "defmacrop" "defn" "defnp" "defp"))
 
 ; * pipe into field without parentheses (function call)
 (binary_operator
@@ -208,7 +208,7 @@
           quoted_end: _ @comment.doc) @comment.doc
         (boolean) @comment.doc
       ]))
-  (#match? @comment.doc.__attribute__ "^(moduledoc|typedoc|doc)$"))
+  (#any-of? @comment.doc.__attribute__ "moduledoc" "typedoc" "doc"))
 
 ; Module
 

--- a/queries/injections.scm
+++ b/queries/injections.scm
@@ -2,6 +2,6 @@
 ((sigil
   (sigil_name) @_sigil_name
   (quoted_content) @injection.content)
- (#match? @_sigil_name "^(H|LVN)$")
+ (#any-of? @_sigil_name "H" "LVN")
  (#set! injection.language "heex")
  (#set! injection.combined))

--- a/queries/tags.scm
+++ b/queries/tags.scm
@@ -4,7 +4,7 @@
 (call
   target: (identifier) @ignore
   (arguments (alias) @name)
-  (#match? @ignore "^(defmodule|defprotocol)$")) @definition.module
+  (#any-of? @ignore "defmodule" "defprotocol")) @definition.module
 
 ; * functions/macros
 (call
@@ -20,14 +20,14 @@
         left: (call target: (identifier) @name)
         operator: "when")
     ])
-  (#match? @ignore "^(def|defp|defdelegate|defguard|defguardp|defmacro|defmacrop|defn|defnp)$")) @definition.function
+  (#any-of? @ignore "def" "defp" "defdelegate" "defguard" "defguardp" "defmacro" "defmacrop" "defn" "defnp")) @definition.function
 
 ; References
 
 ; ignore calls to kernel/special-forms keywords
 (call
   target: (identifier) @ignore
-  (#match? @ignore "^(def|defp|defdelegate|defguard|defguardp|defmacro|defmacrop|defn|defnp|defmodule|defprotocol|defimpl|defstruct|defexception|defoverridable|alias|case|cond|else|for|if|import|quote|raise|receive|require|reraise|super|throw|try|unless|unquote|unquote_splicing|use|with)$"))
+  (#any-of? @ignore "def" "defp" "defdelegate" "defguard" "defguardp" "defmacro" "defmacrop" "defn" "defnp" "defmodule" "defprotocol" "defimpl" "defstruct" "defexception" "defoverridable" "alias" "case" "cond" "else" "for" "if" "import" "quote" "raise" "receive" "require" "reraise" "super" "throw" "try" "unless" "unquote" "unquote_splicing" "use" "with"))
 
 ; ignore module attributes
 (unary_operator


### PR DESCRIPTION
The `(#match? @foo "^(bar|baz)$")` predicate was a workaround necessary when `#any-of?` was not broadly supported. Now that it has been standard for a while, we can switch these uses of `#match?` to `#any-of?`.

https://tree-sitter.github.io/tree-sitter/using-parsers/queries/3-predicates-and-directives.html#the-any-of-predicate