### PR TITLE
Include LICENSE file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "Apache-2.0"
 
 build = "bindings/rust/build.rs"
 include = [
+  "LICENSE",
   "bindings/rust/*",
   "grammar.js",
   "queries/*",


### PR DESCRIPTION
This is needed by the Apache license terms

```
$ cargo package --list --no-verify --allow-dirty | grep LICENSE
LICENSE
```