### PR TITLE
feat: inject sigils

### DIFF
--- a/queries/injections.scm
+++ b/queries/injections.scm
@@ -14,14 +14,6 @@
  (#set! injection.language "regex")
  (#set! injection.combined))
 
-; Json
-((sigil
-  (sigil_name) @_sigil_name
-  (quoted_content) @injection.content)
- (#any-of? @_sigil_name "j" "J")
- (#set! injection.language "json")
- (#set! injection.combined))
-
 ; SQL injection
 ((sigil
   (sigil_name) @_sigil_name
@@ -30,28 +22,12 @@
  (#set! injection.language "sql")
  (#set! injection.combined))
 
-; Surface
-((sigil
-  (sigil_name) @_sigil_name
-  (quoted_content) @injection.content)
- (#eq? @_sigil_name "F")
- (#set! injection.language "surface")
- (#set! injection.combined))
-
 ; Markdown
 ((sigil
   (sigil_name) @_sigil_name
   (quoted_content) @injection.content)
  (#eq? @_sigil_name "MD")
  (#set! injection.language "markdown")
- (#set! injection.combined))
-
-; Zig
-((sigil
-  (sigil_name) @_sigil_name
-  (quoted_content) @injection.content)
- (#any-of? @_sigil_name "z" "Z")
- (#set! injection.language "zig")
  (#set! injection.combined))
 
 ; Python
@@ -68,14 +44,6 @@
   (quoted_content) @injection.content)
  (#eq? @_sigil_name "JS")
  (#set! injection.language "javascript")
- (#set! injection.combined))
-
-; Svelte
-((sigil
-  (sigil_name) @_sigil_name
-  (quoted_content) @injection.content)
- (#eq? @_sigil_name "V")
- (#set! injection.language "svelte")
  (#set! injection.combined))
 
 ; Vue

--- a/queries/injections.scm
+++ b/queries/injections.scm
@@ -2,8 +2,24 @@
 ((sigil
   (sigil_name) @_sigil_name
   (quoted_content) @injection.content)
- (#any-of? @_sigil_name "H" "LVN")
+ (#any-of? @_sigil_name "H" "LVN" "HOLO")
  (#set! injection.language "heex")
+ (#set! injection.combined))
+
+; Regex
+((sigil
+  (sigil_name) @_sigil_name
+  (quoted_content) @injection.content)
+ (#any-of? @_sigil_name "r" "R")
+ (#set! injection.language "regex")
+ (#set! injection.combined))
+
+; Json
+((sigil
+  (sigil_name) @_sigil_name
+  (quoted_content) @injection.content)
+ (#any-of? @_sigil_name "j" "J")
+ (#set! injection.language "json")
  (#set! injection.combined))
 
 ; SQL injection
@@ -12,4 +28,60 @@
   (quoted_content) @injection.content)
  (#eq? @_sigil_name "SQL")
  (#set! injection.language "sql")
+ (#set! injection.combined))
+
+; Surface
+((sigil
+  (sigil_name) @_sigil_name
+  (quoted_content) @injection.content)
+ (#eq? @_sigil_name "F")
+ (#set! injection.language "surface")
+ (#set! injection.combined))
+
+; Markdown
+((sigil
+  (sigil_name) @_sigil_name
+  (quoted_content) @injection.content)
+ (#eq? @_sigil_name "MD")
+ (#set! injection.language "markdown")
+ (#set! injection.combined))
+
+; Zig
+((sigil
+  (sigil_name) @_sigil_name
+  (quoted_content) @injection.content)
+ (#any-of? @_sigil_name "z" "Z")
+ (#set! injection.language "zig")
+ (#set! injection.combined))
+
+; Python
+((sigil
+  (sigil_name) @_sigil_name
+  (quoted_content) @injection.content)
+ (#eq? @_sigil_name "PY")
+ (#set! injection.language "python")
+ (#set! injection.combined))
+
+; JavaScript
+((sigil
+  (sigil_name) @_sigil_name
+  (quoted_content) @injection.content)
+ (#eq? @_sigil_name "JS")
+ (#set! injection.language "javascript")
+ (#set! injection.combined))
+
+; Svelte
+((sigil
+  (sigil_name) @_sigil_name
+  (quoted_content) @injection.content)
+ (#eq? @_sigil_name "V")
+ (#set! injection.language "svelte")
+ (#set! injection.combined))
+
+; Vue
+((sigil
+  (sigil_name) @_sigil_name
+  (quoted_content) @injection.content)
+ (#eq? @_sigil_name "VUE")
+ (#set! injection.language "vue")
  (#set! injection.combined))


### PR DESCRIPTION
Based on #75 and #84 I'm assuming it's fine to inject more sigils.

I've included ones from https://elixir-lang.org/blog/2025/08/18/interop-and-portability, https://github.com/nvim-treesitter/nvim-treesitter/blob/main/runtime/queries/elixir/injections.scm, and a couple others that seems popular.

Note that `HOLO` templates are not HEEx but that's the closest language, although I'm not sure about it.