### PR TITLE
Include WASM in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "format": "prettier --write grammar.js && clang-format -i src/scanner.c",
     "format-check": "prettier --check grammar.js && cat src/scanner.c | clang-format src/scanner.c | diff src/scanner.c -",
     "install": "node-gyp-build",
-    "prepack": "tree-sitter build --wasm",
     "prestart": "tree-sitter build --wasm",
     "start": "tree-sitter playground"
   },


### PR DESCRIPTION
## Summary

- Add `*.wasm` to `files` so the pre-built WASM is included in the npm tarball
- Add `prepack` script to build the WASM before publishing

Other tree-sitter grammars (Go, JS, TS) already ship pre-built WASM files, enabling `web-tree-sitter` users to load grammars via `require.resolve` without building from source.