### PR TITLE
Update module path to elixir-lang

### DIFF
--- a/bindings/go/binding_test.go
+++ b/bindings/go/binding_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	tree_sitter "github.com/tree-sitter/go-tree-sitter"
-	tree_sitter_elixir "github.com/tree-sitter/tree-sitter-elixir/bindings/go"
+	tree_sitter_elixir "github.com/elixir-lang/tree-sitter-elixir/bindings/go"
 )
 
 func TestCanLoadGrammar(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tree-sitter/tree-sitter-elixir
+module github.com/elixir-lang/tree-sitter-elixir
 
 go 1.23
 


### PR DESCRIPTION
Currently the go bindings point to the old repo, preventing them from use.