### PR TITLE
Regenerate `tree-sitter-elixir.pc.in`

### DIFF
--- a/bindings/c/tree-sitter-elixir.pc.in
+++ b/bindings/c/tree-sitter-elixir.pc.in
@@ -1,11 +1,10 @@
-prefix=@PREFIX@
-libdir=@LIBDIR@
-includedir=@INCLUDEDIR@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: tree-sitter-elixir
-Description: Elixir grammar for tree-sitter
-URL: @URL@
-Version: @VERSION@
-Requires: @REQUIRES@
-Libs: -L${libdir} @ADDITIONAL_LIBS@ -ltree-sitter-elixir
+Description: @PROJECT_DESCRIPTION@
+URL: @PROJECT_HOMEPAGE_URL@
+Version: @PROJECT_VERSION@
+Libs: -L${libdir} -ltree-sitter-elixir
 Cflags: -I${includedir}


### PR DESCRIPTION
Fixes `Illegal char '@' (0x40) in: @VERSION@` fatal error when building an RPM package.